### PR TITLE
Change version of clang to a prebuilt one

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,11 @@ export KBUILD_BUILD_HOST=grapheneos
 
 PATH="$TOP/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin:$PATH"
 PATH="$TOP/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin:$PATH"
-PATH="$TOP/prebuilts/clang/host/linux-x86/clang-r346389b/bin:$PATH"
+PATH="$TOP/prebuilts/clang/host/linux-x86/clang-4393122/bin:$PATH"
 PATH="$TOP/prebuilts/misc/linux-x86/lz4:$PATH"
 PATH="$TOP/prebuilts/misc/linux-x86/dtc:$PATH"
 PATH="$TOP/prebuilts/misc/linux-x86/libufdt:$PATH"
-export LD_LIBRARY_PATH="$TOP/prebuilts/clang/host/linux-x86/clang-r346389b/lib64:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$TOP/prebuilts/clang/host/linux-x86/clang-4393122/lib64:$LD_LIBRARY_PATH"
 
 make O=out ARCH=arm64 bonito_defconfig
 

--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,11 @@ export KBUILD_BUILD_HOST=grapheneos
 
 PATH="$TOP/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin:$PATH"
 PATH="$TOP/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin:$PATH"
-PATH="$TOP/prebuilts/clang/host/linux-x86/clang-4393122/bin:$PATH"
+PATH="$TOP/prebuilts/clang/host/linux-x86/clang-4691093/bin:$PATH"
 PATH="$TOP/prebuilts/misc/linux-x86/lz4:$PATH"
 PATH="$TOP/prebuilts/misc/linux-x86/dtc:$PATH"
 PATH="$TOP/prebuilts/misc/linux-x86/libufdt:$PATH"
-export LD_LIBRARY_PATH="$TOP/prebuilts/clang/host/linux-x86/clang-4393122/lib64:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$TOP/prebuilts/clang/host/linux-x86/clang-4691093/lib64:$LD_LIBRARY_PATH"
 
 make O=out ARCH=arm64 bonito_defconfig
 


### PR DESCRIPTION
Currently clang version r346389b is not included in the platform_manifest. This leads to the following error when compiled on Ubuntu with the system default clang: `/usr/bin/as: unrecognized option '-mfloat-abi=soft'`

Version 4691093 is used by google in the AOSP for Android P builds (ref: https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/)